### PR TITLE
react dependency consistent with peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "babel-runtime": ">=5.0.0",
     "is-retina": "^1.0.3",
     "md5": "^2.0.0",
-    "react": "^0.14.0",
-    "react-addons-shallow-compare": "^0.14.0"
+    "react": ">=0.14",
+    "react-addons-shallow-compare": ">=0.14"
   }
 }


### PR DESCRIPTION
If you're not using `react ^0.14.0`, current setup causes npm to require react twice. Example:

![react dependency](https://cldup.com/ifQM_shVfe.png)
